### PR TITLE
Attempt to read and set custom Audience Server from settings

### DIFF
--- a/src/main/java/com/mparticle/kits/AdobeKitBase.java
+++ b/src/main/java/com/mparticle/kits/AdobeKitBase.java
@@ -18,10 +18,11 @@ import java.util.Map;
 
 abstract class AdobeKitBase extends KitIntegration implements KitIntegration.AttributeListener, KitIntegration.PushListener, KitIntegration.ApplicationStateListener {
 
-    private static final String MARKETING_CLOUD_ID_KEY = "mid";
+    static final String MARKETING_CLOUD_ID_KEY = "mid";
     private static final String ORG_ID_KEY = "organizationID";
     private static final String AUDIENCE_MANAGER_BLOB = "aamb";
     private static final String AUDIENCE_MANAGER_LOCATION_HINT = "aamlh";
+    static final String AUDIENCE_MANAGER_SERVER = "audienceManagerServer";
 
     private static final String D_MID_KEY = "d_mid";
     private static final String D_ORIG_ID_KEY = "d_orgid";
@@ -45,6 +46,9 @@ abstract class AdobeKitBase extends KitIntegration implements KitIntegration.Att
     @Override
     protected List<ReportingMessage> onKitCreate(Map<String, String> map, Context context) throws IllegalArgumentException {
         mOrgId = map.get(ORG_ID_KEY);
+        if (map.containsKey(AUDIENCE_MANAGER_SERVER)) {
+            url = map.get(AUDIENCE_MANAGER_SERVER);
+        }
         getMarketingCloudId();
         return null;
     }

--- a/src/test/java/com/mparticle/kits/AdobeKitTest.java
+++ b/src/test/java/com/mparticle/kits/AdobeKitTest.java
@@ -3,11 +3,13 @@ package com.mparticle.kits;
 import android.content.Context;
 
 import com.mparticle.MParticle;
+import com.mparticle.internal.KitManager;
 import com.mparticle.internal.MPUtility;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,6 +74,22 @@ public class AdobeKitTest {
         String url2 = getKit().encodeIds("<MCID>", "<ORG ID>", "<BLOB>", "<REGION>", "<PUSH TOKEN>", "<GAID>", userIdentities);
         String testUrls2 = "d_mid=<MCID>&d_ver=2&d_orgid=<ORG ID>&d_cid=20914%01<GAID>&d_cid=20919%01<PUSH TOKEN>&dcs_region=<REGION>&d_blob=<BLOB>&d_ptfm=android&d_cid_ic=customerid%01<CUSTOMER ID>&d_cid_ic=email%01<EMAIL>";
         assertEqualUnorderedUrlParams(url2, testUrls2);
+    }
+
+    @Test
+    public void testGetUrlInstance() throws Exception {
+        AdobeKit kit = getKit();
+        kit.setKitManager(Mockito.mock(KitManagerImpl.class));
+        Map<String, String> integrationAttributes = new HashMap<>();
+        integrationAttributes.put(AdobeKitBase.MARKETING_CLOUD_ID_KEY, "foo");
+        Mockito.when(kit.getKitManager().getIntegrationAttributes(Mockito.any(KitIntegration.class))).thenReturn(integrationAttributes);
+
+        Map settings = new HashMap<>();
+        settings.put(AdobeKitBase.AUDIENCE_MANAGER_SERVER, "some.random.url");
+        kit.onKitCreate(settings, Mockito.mock(Context.class));
+
+        String url = kit.getUrl();
+        assertEquals(url, "some.random.url");
     }
 
     private void assertEqualUnorderedUrlParams(String url1, String url2) {


### PR DESCRIPTION
This change allows us to override the "dpm.demdex.net" portion of the Adobe Audience Url invoke in order to set "marketing cloud id", "dcs blob" and "dcs region" in integrationAttributes.

These changes will also be reflected in the Adobe Media Kit, although in a separate commit.