### PR TITLE
fix: Update method for setting MCID in Kotlin port versions

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
+++ b/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
@@ -153,7 +153,7 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
             var marketingCloudId = jsonObject.getString(D_MID_KEY)
             val dcsRegion = jsonObject.optString(DCS_REGION_KEY)
             val dBlob = jsonObject.optString(D_BLOB_KEY)
-            marketingCloudId = marketingCloudId
+            setMarketingCloudId(marketingCloudId)
             setDcsRegion(dcsRegion)
             setDBlob(dBlob)
         } catch (e: JSONException) {
@@ -165,7 +165,7 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
      * fetch the MarketingCloudId. If it can't be found in our storage, assume that this
      * user is migrating from the Adobe SDK and try to fetch it from where the Adobe SDK would store it
      */
-    private var marketingCloudId: String?
+    private val marketingCloudId: String?
          get() {
             var marketingCloudId = integrationAttributes[MARKETING_CLOUD_ID_KEY]
             if (KitUtils.isEmpty(marketingCloudId)) {
@@ -183,11 +183,13 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
             }
             return marketingCloudId
         }
-        private set(id) {
-            val integrationAttributes = integrationAttributes
-            integrationAttributes[MARKETING_CLOUD_ID_KEY] = id
-            setIntegrationAttributes(integrationAttributes)
-        }
+
+    private fun setMarketingCloudId(id: String) {
+        val integrationAttributes = integrationAttributes
+        integrationAttributes[MARKETING_CLOUD_ID_KEY] = id
+        setIntegrationAttributes(integrationAttributes)
+    }
+
     private val dcsRegion: String?
          get() = integrationAttributes[AUDIENCE_MANAGER_LOCATION_HINT]
 


### PR DESCRIPTION
## Summary
One of our clients reported that the newer versions of the Adobe Android kits including 5.44.2 and 5.45.2 are not working when using our getMarketingCloudId functions which we recommend per our [docs](https://docs.mparticle.com/integrations/amc/event/#retrieve-mid-for-the-current-user).  I was able to reproduce with both my Android app and sample app shared by the client. After further investigation it seems that the MCID setter was not being used even though its defined. The fix here is have a function that sets the MCID and is called when the response is received from the Adobe API

## Testing Plan
Imported the kit locally to the sample app and was able to see getMarketingCloudId return back the MCID.

