### PR TITLE
fix: Stop mcid changing on cold app start

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
+++ b/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
@@ -28,7 +28,7 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
         if (map.containsKey(AUDIENCE_MANAGER_SERVER)) {
             url = map[AUDIENCE_MANAGER_SERVER]
         }
-        marketingCloudId
+        syncIds()
         return emptyList()
     }
 
@@ -178,7 +178,7 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
                     marketingCloudIdKey = adobeSharedPrefs.getString("ADBMOBILE_PERSISTED_MID", null)
                 }
                 if (!KitUtils.isEmpty(marketingCloudIdKey)) {
-                    return marketingCloudIdKey
+                    marketingCloudId = marketingCloudIdKey
                 }
             }
             return marketingCloudIdKey
@@ -186,8 +186,10 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
 
         private set(id) {
             val integrationAttributes = integrationAttributes
-            integrationAttributes[MARKETING_CLOUD_ID_KEY] = id
-            setIntegrationAttributes(integrationAttributes)
+            if ((id?.length ?: 0 ) > 0 && !id.equals(integrationAttributes[MARKETING_CLOUD_ID_KEY])) {
+                integrationAttributes[MARKETING_CLOUD_ID_KEY] = id
+                setIntegrationAttributes(integrationAttributes)
+            }
         }
 
     private val dcsRegion: String?

--- a/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
+++ b/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
@@ -82,26 +82,24 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
         return false
     }
 
+    @Synchronized
     private fun syncIds() {
         if (this.requestInProgress) return
-
-        synchronized(this) {
-            requestInProgress = true
-            executeNetworkRequest {
-                try {
-                    val url = URL("https", url, "/id?" + encodeIds())
-                    val urlConnection = url.openConnection() as HttpURLConnection
-                    urlConnection.connectTimeout = 2000
-                    urlConnection.readTimeout = 10000
-                    if (urlConnection.responseCode in 200..299) {
-                        val response = MPUtility.getJsonResponse(urlConnection)
-                        parseResponse(response)
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
+        requestInProgress = true
+        executeNetworkRequest {
+            try {
+                val url = URL("https", url, "/id?" + encodeIds())
+                val urlConnection = url.openConnection() as HttpURLConnection
+                urlConnection.connectTimeout = 2000
+                urlConnection.readTimeout = 10000
+                if (urlConnection.responseCode in 200..299) {
+                    val response = MPUtility.getJsonResponse(urlConnection)
+                    parseResponse(response)
                 }
-                requestInProgress = false
+            } catch (e: Exception) {
+                e.printStackTrace()
             }
+            requestInProgress = false
         }
     }
 

--- a/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
+++ b/src/main/kotlin/com/mparticle/kits/AdobeKitBase.kt
@@ -186,7 +186,7 @@ abstract class AdobeKitBase : KitIntegration(), AttributeListener, PushListener,
 
         private set(id) {
             val integrationAttributes = integrationAttributes
-            if ((id?.length ?: 0 ) > 0 && !id.equals(integrationAttributes[MARKETING_CLOUD_ID_KEY])) {
+            if (!id.isNullOrEmpty() && !id.equals(integrationAttributes[MARKETING_CLOUD_ID_KEY])) {
                 integrationAttributes[MARKETING_CLOUD_ID_KEY] = id
                 setIntegrationAttributes(integrationAttributes)
             }


### PR DESCRIPTION
## Summary
- Fix MCID changing on cold app start by handling race condition when two network requests could be happening at same time and second mcid value overwriting first one
- Saving MCID into shared pref as backup in case fetching it from `integrationAttributes` returns null
- Also Fetch MCID on cold app start

## Testing Plan
- Regression tests should pass
- MCID stays same on cold app starts

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4935
